### PR TITLE
Fixes #7, relative links are correctly converted to absolute links

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E501
+ignore = E501, W503
 exclude =
     .git,
     __pycache__,

--- a/link_checker.py
+++ b/link_checker.py
@@ -175,7 +175,6 @@ for licens in all_links:
     filename = licens.string[:-5]
     base_url = create_base_link(filename)
     print("URL:", base_url)
-    output_write("URL:", base_url)
     source_html = requests.get(page_url, headers=header)
     license_soup = BeautifulSoup(source_html.content, "lxml")
     links_in_license = license_soup.find_all("a")
@@ -197,7 +196,7 @@ for licens in all_links:
             if caught_errors == 1:
                 if not verbose:
                     print("Errors:")
-                output_write("\n{}".format(licens.string))
+                output_write("\n{}\nURL: ".format(licens.string, base_url))
             err_code = 1
             print(status, "-\t", link)
             output_write(status, "-\t", link)

--- a/link_checker.py
+++ b/link_checker.py
@@ -50,7 +50,16 @@ def get_all_license():
     return links
 
 
-def create_absolute_link(link_analysis, href):
+def create_absolute_link(link_analysis):
+    """Creates absolute links from relative links
+
+    Args:
+        link_analysis (class 'urllib.parse.SplitResult'): Link splitted by urlsplit, that is to be converted
+
+    Returns:
+        str: absolute link
+    """
+    href = link_analysis.geturl()
     if (
         link_analysis.scheme == ""
         and link_analysis.netloc == ""
@@ -60,18 +69,18 @@ def create_absolute_link(link_analysis, href):
     return href
 
 
-def check_existing(link, base_url):
+def check_existing(link):
     """This function checks if the link is already present in scraped_links.
 
     Args:
         link (bs4.element.Tag): The anchor tag extracted using BeautifulSoup which is to be checked
 
     Returns:
-        String or Number: The status of the link
+        String or Number: The status of the link(200) or error message
     """
     href = link["href"]
     analyse = urlsplit(href)
-    href = create_absolute_link(analyse, href)
+    href = create_absolute_link(analyse)
     status = scraped_links.get(href)
     if status:
         return status
@@ -82,6 +91,14 @@ def check_existing(link, base_url):
 
 
 def get_status(href):
+    """Sends request to link and returns status_code or Timeout Error
+
+    Args:
+        href (str): href extracted from anchor tag which is to be scraped
+
+    Returns:
+        int or str: Status code of response or "Timeout Error"
+    """
     try:
         res = requests.get(href, headers=header, timeout=10)
     except requests.exceptions.Timeout:
@@ -94,10 +111,10 @@ def scrape(href):
     """Checks the status of the link and returns the status code 200 or the error encountered.
 
     Args:
-        link (bs4.element.Tag): The anchor tag extracted using BeautifulSoup which is to be checked
+        href (str): href extracted from anchor tag which is to be scraped
 
     Returns:
-        String or Number: Error encountered or Status code 200
+        int or str: Error encountered or Status code 200
     """
     analyse = urlsplit(href)
     if analyse.scheme == "" or analyse.scheme in ["https", "http"]:
@@ -190,7 +207,7 @@ for licens in all_links:
         if href[0] == "#":
             verbose_print("Skipping internal link -\t", link)
             continue
-        status = check_existing(link, base_url)
+        status = check_existing(link)
         if status not in [200, "ignore"]:
             caught_errors += 1
             if caught_errors == 1:

--- a/link_checker.py
+++ b/link_checker.py
@@ -89,11 +89,7 @@ def scrape(link, filename):
     """
     href = link["href"]
     analyse = urlsplit(href)
-    if (
-        analyse.scheme == ""
-        and analyse.netloc == ""
-        and analyse.path != ""
-    ):
+    if analyse.scheme == "" and analyse.netloc == "" and analyse.path != "":
         base_link = create_base_link(filename)
         href = urljoin(base_link, href)
         res = get_status(href)

--- a/link_checker.py
+++ b/link_checker.py
@@ -213,7 +213,7 @@ for licens in all_links:
             if caught_errors == 1:
                 if not verbose:
                     print("Errors:")
-                output_write("\n{}\nURL: ".format(licens.string, base_url))
+                output_write("\n{}\nURL: {}".format(licens.string, base_url))
             err_code = 1
             print(status, "-\t", link)
             output_write(status, "-\t", link)


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #7 

**Description**
Previously, all relative links were appended to `https://www.creativecommons.org` to generate absolute link for checking. This method was wrong as the links were relative to the URL on which the license will be displayed, due to which we got false negatives and false positives. This PR fixes the issue by adding the functionality of generating `base_url` from the filename of license file and appending the relative to base_url to generate absolute link

**Other information**
<!-- Add any other information below or delete the "Other Information" line entirely. -->
To help with debugging, the URL of the license file is printed in console in normal mode as well as `verbose` mode.
Also when using `--output-error` flag the error file also includes the URL.
One such example of the --output-error flag run locally can be viewed [here](https://101-192115329-gh.circle-artifacts.com/0/script-result/errorlog.txt)

**Checklist:**
- [X] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [X] My pull request targets the `master` branch of the repository.
- [X] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [X] I added or updated documentation (if applicable).
- [X] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
