### PR TITLE
Added multiprocessing support

### DIFF
--- a/link_checker.py
+++ b/link_checker.py
@@ -18,6 +18,7 @@ HEADER = {
 }
 scraped_links = {}
 map_broken_links = {}
+lock = Lock()
 
 
 parser = argparse.ArgumentParser(description="Script to check broken links")

--- a/link_checker.py
+++ b/link_checker.py
@@ -16,6 +16,7 @@ output_err = False
 HEADER = {
     "User-Agent": "Mozilla/5.0 (X11; Linux i686 on x86_64; rv:10.0) Gecko/20100101 Firefox/10.0"
 }
+GOOD_RESPONSE = [200, 300, 301, 302, "ignore"]
 scraped_links = {}
 map_broken_links = {}
 lock = Lock()
@@ -89,13 +90,13 @@ def check_existing(link):
     href = create_absolute_link(analyse)
     status = scraped_links.get(href)
     if status:
-        if status not in [200, "ignore"]:
+        if status not in GOOD_RESPONSE:
             map_broken_links[href].append(base_url)
         return status
     else:
         status = scrape(href)
         scraped_links[href] = status
-        if status not in [200, "ignore"]:
+        if status not in GOOD_RESPONSE:
             map_broken_links[href] = [base_url]
         return status
 
@@ -201,12 +202,12 @@ def output_summary(num_errors):
             output_write(url)
 
 
-def check_link(link, licens_name, base_url):
+def check_link(link, license_name, base_url):
     """Function that checks the link for errors and warning, and prints it. This is the target for thread.
 
     Args:
         link (class 'bs4.element.tag'): The link that is to be checked for errors or warning
-        licens_name (str): Name of the license file
+        license_name (str): Name of the license file
         base_url (str): The url on which the license file is displayed
     """
     global caught_errors, err_code
@@ -221,12 +222,12 @@ def check_link(link, licens_name, base_url):
         return
     status = check_existing(link)
     with lock:
-        if status not in [200, "ignore"]:
+        if status not in GOOD_RESPONSE:
             caught_errors += 1
             if caught_errors == 1:
                 if not verbose:
                     print("Errors:")
-                output_write("\n{}\nURL: {}".format(licens_name, base_url))
+                output_write("\n{}\nURL: {}".format(license_name, base_url))
             err_code = 1
             print(status, "-\t", link)
             output_write(status, "-\t", link)


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #12 

**Description**
The script can now use multithreading. The maximum number of threads are set to 5. Due to this, on local testing the execution time reduced from over 5 minutes to 3:20 .

**Other information**
Threading is only implemented for checking links within the license. The threads still suffer from GIL(Global Interpretor Lock) of python.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
