### PR TITLE
Added --local flag functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ err_file.txt
 .pytest_cache
 test-reports
 .coverage
+test_file.txt

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -251,10 +251,10 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:530d8bf8cc93a34019d08142593cf4d78a05c890da8cf87ffa3120af53772238",
-                "sha256:f78e99616b6f1a4745c0580e170251ef1bbafc0d0513e270c4bd281bf29d2800"
+                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
+                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
             ],
-            "version": "==2.4.1"
+            "version": "==2.4.0"
         },
         "pytest": {
             "hashes": [

--- a/link_checker.py
+++ b/link_checker.py
@@ -7,6 +7,7 @@ import argparse
 import sys
 import time
 import traceback
+import os
 
 # Third-party
 from bs4 import BeautifulSoup
@@ -19,6 +20,7 @@ START_TIME = time.time()
 ERR_CODE = 0
 VERBOSE = False
 OUTPUT_ERR = False
+LOCAL = False
 HEADER = {
     "User-Agent": "Mozilla/5.0 (X11; Linux i686 on x86_64; rv:10.0) Gecko/20100101 Firefox/10.0"
 }
@@ -48,6 +50,7 @@ def parse_argument(args):
     global VERBOSE
     global OUTPUT_ERR
     global OUTPUT
+    global LOCAL
     # Setup argument parser
     parser = argparse.ArgumentParser(
         description="Script to check broken links"
@@ -67,15 +70,38 @@ def parse_argument(args):
         type=argparse.FileType("w", encoding="utf-8"),
         dest="OUTPUT",
     )
+    parser.add_argument(
+        "--local",
+        help="Scrapes license files from local file system",
+        action="store_true",
+    )
     args = parser.parse_args(args)
     if args.verbose:
         VERBOSE = True
     if args.OUTPUT:
         OUTPUT = args.OUTPUT
         OUTPUT_ERR = True
+    if args.local:
+        LOCAL = True
 
 
-def get_all_license():
+def get_local_license():
+    all_files = os.listdir("../creativecommons.org/docroot/legalcode")
+    test_order = ["zero", "4.0", "3.0"]
+    links_ordered = list()
+    for version in test_order:
+        for link in all_files:
+            if ".html" in link and version in link:
+                links_ordered.append(link)
+    for link in all_files:
+        if ".html" in link and link not in links_ordered:
+            links_ordered.append(link)
+    links = links_ordered
+    print("Number of files to be checked:", len(links))
+    return links
+
+
+def get_global_license():
     """This function scrapes all the license file in the repo:
     https://github.com/creativecommons/creativecommons.org/tree/master/docroot/legalcode
 
@@ -399,7 +425,10 @@ def output_summary(all_links, num_errors):
 def main():
     parse_argument(sys.argv[1:])
 
-    all_links = get_all_license()
+    if LOCAL:
+        all_links = get_local_license()
+    else:
+        all_links = get_global_license()
 
     GITHUB_BASE = (
         "https://raw.githubusercontent.com/creativecommons"
@@ -408,15 +437,19 @@ def main():
 
     errors_total = 0
     for license in all_links:
+        try:
+            license_name = license.string
+        except AttributeError:
+            license_name = license
         caught_errors = 0
-        page_url = GITHUB_BASE + license.string
+        page_url = GITHUB_BASE + license_name
         print("\n")
-        print("Checking:", license.string)
+        print("Checking:", license_name)
         # Refer to issue for more info on samplingplus_1.0.br.htm:
         #   https://github.com/creativecommons/cc-link-checker/issues/9
-        if license.string == "samplingplus_1.0.br.html":
+        if license_name == "samplingplus_1.0.br.html":
             continue
-        filename = license.string[:-5]
+        filename = license_name[:-5]
         base_url = create_base_link(filename)
         print("URL:", base_url)
         source_html = request_text(page_url)
@@ -461,7 +494,7 @@ def main():
                 stored_links,
                 stored_result,
                 base_url,
-                license.string,
+                license_name,
                 stored_anchors,
             )
 

--- a/link_checker.py
+++ b/link_checker.py
@@ -487,7 +487,7 @@ def main():
         #   https://github.com/creativecommons/cc-link-checker/issues/9
         if license_name == "samplingplus_1.0.br.html":
             continue
-        filename = license_name[:-len(".html")]
+        filename = license_name[: -len(".html")]
         base_url = create_base_link(filename)
         print("URL:", base_url)
         if LOCAL:

--- a/link_checker.py
+++ b/link_checker.py
@@ -93,7 +93,15 @@ def get_local_license():
     Returns:
         list: list of file names of license file
     """
-    all_files = os.listdir(LICENSE_LOCAL_PATH)
+    try:
+        all_files = os.listdir(LICENSE_LOCAL_PATH)
+    except FileNotFoundError:
+        raise CheckerError(
+            "Local license path({}) does not exist".format(LICENSE_LOCAL_PATH)
+        )
+    # Catching permission denied(OS ERROR) or other errors
+    except:
+        raise
     links_ordered = list()
     # Test newer licenses first (they are the most volatile) and exclude
     # non-.html files

--- a/link_checker.py
+++ b/link_checker.py
@@ -87,6 +87,11 @@ def parse_argument(args):
 
 
 def get_local_license():
+    """This function get all the licenses stored locally
+
+    Returns:
+        list: list of file names of license file
+    """
     all_files = os.listdir(LICENSE_LOCAL_PATH)
     test_order = ["zero", "4.0", "3.0"]
     links_ordered = list()
@@ -162,6 +167,14 @@ def request_text(page_url):
 
 
 def request_local_text(license_name):
+    """This function reads license content from license file stored in local file system
+
+    Args:
+        license_name (str): Name of the license
+
+    Returns:
+        str: Content of license file
+    """
     filename = license_name
     with open(LICENSE_LOCAL_PATH + "/" + filename, "r") as lic:
         return lic.read()

--- a/link_checker.py
+++ b/link_checker.py
@@ -487,7 +487,7 @@ def main():
         #   https://github.com/creativecommons/cc-link-checker/issues/9
         if license_name == "samplingplus_1.0.br.html":
             continue
-        filename = license_name[:-5]
+        filename = license_name[:-len(".html")]
         base_url = create_base_link(filename)
         print("URL:", base_url)
         if LOCAL:

--- a/link_checker.py
+++ b/link_checker.py
@@ -29,6 +29,7 @@ MAP_BROKEN_LINKS = {}
 GOOD_RESPONSE = [200, 300, 301, 302]
 OUTPUT = None
 REQUESTS_TIMEOUT = 5
+LICENSE_LOCAL_PATH = "../creativecommons.org/docroot/legalcode"
 
 
 class CheckerError(Exception):
@@ -86,7 +87,7 @@ def parse_argument(args):
 
 
 def get_local_license():
-    all_files = os.listdir("../creativecommons.org/docroot/legalcode")
+    all_files = os.listdir(LICENSE_LOCAL_PATH)
     test_order = ["zero", "4.0", "3.0"]
     links_ordered = list()
     for version in test_order:
@@ -158,6 +159,12 @@ def request_text(page_url):
     except:
         raise
     return fetched_text
+
+
+def request_local_text(license_name):
+    filename = license_name
+    with open(LICENSE_LOCAL_PATH + "/" + filename, "r") as lic:
+        return lic.read()
 
 
 def create_base_link(filename):
@@ -452,7 +459,10 @@ def main():
         filename = license_name[:-5]
         base_url = create_base_link(filename)
         print("URL:", base_url)
-        source_html = request_text(page_url)
+        if LOCAL:
+            source_html = request_local_text(license_name)
+        else:
+            source_html = request_text(page_url)
         license_soup = BeautifulSoup(source_html, "lxml")
         links_in_license = license_soup.find_all("a")
         verbose_print("Number of links found:", len(links_in_license))

--- a/test_link_checker.py
+++ b/test_link_checker.py
@@ -11,6 +11,7 @@ def reset_global():
     link_checker.OUTPUT_ERR = False
     link_checker.MEMOIZED_LINKS = {}
     link_checker.MAP_BROKEN_LINKS = {}
+    link_checker.LOCAL = False
     return
 
 

--- a/test_link_checker.py
+++ b/test_link_checker.py
@@ -326,5 +326,6 @@ def test_request_local_text():
     with open("test_file.txt", "w") as test_file:
         test_file.write(random_string)
         test_file.close
+    # Change local path to current directory
     link_checker.LICENSE_LOCAL_PATH = "./"
     assert link_checker.request_local_text("test_file.txt") == random_string

--- a/test_link_checker.py
+++ b/test_link_checker.py
@@ -29,8 +29,8 @@ def test_parse_argument(reset_global):
     assert link_checker.OUTPUT.name == "err_file.txt"
 
 
-def test_get_all_license():
-    all_links = link_checker.get_all_license()
+def test_get_global_license():
+    all_links = link_checker.get_global_license()
     assert len(all_links) > 0
 
 

--- a/test_link_checker.py
+++ b/test_link_checker.py
@@ -319,3 +319,12 @@ def test_request_text(URL, error):
         ) == "FAILED to retreive source HTML (https://www.google.com:82) due to {}".format(
             error
         )
+
+
+def test_request_local_text():
+    random_string = "creativecommons cc-link-checker"
+    with open("test_file.txt", "w") as test_file:
+        test_file.write(random_string)
+        test_file.close
+    link_checker.LICENSE_LOCAL_PATH = "./"
+    assert link_checker.request_local_text("test_file.txt") == random_string


### PR DESCRIPTION
**Description**
User can now use the script with `--local` flag to check dead links in license files stored locally. This functionality would give an speed advantage when checking locally, also this would enable the script to be added as an CI for pull requests

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
