### PR TITLE
Added junit-xml script summary output for CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 __pycache__
 venv
 errorlog.txt
-err_file.txt
 .vscode
 .pytest_cache
 test-reports
 .coverage
 test_file.txt
+err_file.txt
+test-summary

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ link_checker = "python ./link_checker.py"
 
 [dev-packages]
 # See https://github.com/pypa/pipenv/issues/1760
-black = {ref = "19.3b0", git = "https://github.com/python/black.git"}
+black = {ref = "19.3b0",git = "https://github.com/python/black.git"}
 flake8 = "*"
 pytest = "*"
 
@@ -18,6 +18,7 @@ beautifulsoup4 = "*"
 grequests = "*"
 lxml = "*"
 requests = "*"
+junit-xml = "*"
 
 [requires]
 python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4f89d044469313c568a08ab174d08dc4030b12e20d2728a345d2e304624fa870"
+            "sha256": "aeaeb66a17073203586e38c5cf98ea3e12066c86f8e6346833208bd375aea2ff"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -94,10 +94,11 @@
         },
         "grequests": {
             "hashes": [
-                "sha256:0f41c4eee83bab39f5543af49665c08681637a0562a5704a3f7b2e4a996531c9"
+                "sha256:8aeccc15e60ec65c7e67ee32e9c596ab2196979815497f85cf863465a1626490",
+                "sha256:eb574b08f69b48c54e1029415f5f3316899ee006daa5624bbc5320648cdfdd52"
             ],
             "index": "pypi",
-            "version": "==0.3.0"
+            "version": "==0.4.0"
         },
         "idna": {
             "hashes": [
@@ -105,6 +106,13 @@
                 "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
             "version": "==2.8"
+        },
+        "junit-xml": {
+            "hashes": [
+                "sha256:602f1c480a19d64edb452bf7632f76b5f2cb92c1938c6e071dcda8ff9541dc21"
+            ],
+            "index": "pypi",
+            "version": "==1.8"
         },
         "lxml": {
             "hashes": [
@@ -141,6 +149,13 @@
             ],
             "index": "pypi",
             "version": "==2.22.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
         },
         "soupsieve": {
             "hashes": [
@@ -214,10 +229,10 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
-                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
+                "sha256:a7ac867b97fdc07ee80a8058fe4435ccd274ecc3b0ed61d852d7d53055528cf9",
+                "sha256:c491ca87294da7cc01902edbe30a5bc6c4c28172b5138ab4e4aa1b9d7bfaeafe"
             ],
-            "version": "==19.0"
+            "version": "==19.1"
         },
         "pluggy": {
             "hashes": [
@@ -249,10 +264,10 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:43c5486cefefa536c9aab528881c992328f020eefe4f6d06332449c365218580",
-                "sha256:d6c5ffe9d0305b9b977f7a642d36b9370954d1da7ada4c62393382cbadad4265"
+                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
+                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
             ],
-            "version": "==2.4.1.1"
+            "version": "==2.4.2"
         },
         "pytest": {
             "hashes": [

--- a/link_checker.py
+++ b/link_checker.py
@@ -12,6 +12,7 @@ import os
 # Third-party
 from bs4 import BeautifulSoup
 import grequests  # WARNING: Always import grequests before requests
+from junit_xml import TestCase, TestSuite
 import requests
 
 
@@ -65,7 +66,7 @@ def parse_argument(args):
     )
     parser.add_argument(
         "--output-error",
-        help="Outputs all link errors to file (default: errorlog.txt) and creates junit-xml type script run summary(test-summary/junit-xml-report.xml) for CI",
+        help="Outputs all link errors to file (default: errorlog.txt)",
         metavar="output_file",
         const="errorlog.txt",
         nargs="?",
@@ -469,18 +470,17 @@ def output_test_summary(errors_total):
     if not os.path.isdir("test-summary"):
         os.mkdir("test-summary")
     with open("test-summary/junit-xml-report.xml", "w") as test_summary:
-        test_summary.write('<?xml version="1.0" encoding="utf-8"?>\n')
-        test_summary.write(
-            f'<testsuite errors="0" name="cc-link-checker" skipped="0" tests="1" time="{time.time()-START_TIME}">\n'
-        )
-        test_summary.write(
-            '<testcase classname="test_broken_links" name="check broken links" file="link_checker.py">\n'
+        time_taken = time.time() - START_TIME
+        test_case = TestCase(
+            "Broken links checker", "License files", time_taken
         )
         if errors_total != 0:
-            test_summary.write(
-                f'<failure message="{errors_total} broken links found">Number of error links: {errors_total}\nNumber of unique broken links: {len(MAP_BROKEN_LINKS.keys())}</failure>\n'
+            test_case.add_failure_info(
+                f"{errors_total} broken links found",
+                f"Number of error links: {errors_total}\nNumber of unique broken links: {len(MAP_BROKEN_LINKS.keys())}",
             )
-        test_summary.write("</testcase></testsuite>")
+        ts = TestSuite("cc-link-checker", [test_case])
+        TestSuite.to_file(test_summary, [ts])
 
 
 def main():

--- a/link_checker.py
+++ b/link_checker.py
@@ -469,16 +469,16 @@ def output_test_summary(errors_total):
     if not os.path.isdir("test-summary"):
         os.mkdir("test-summary")
     with open("test-summary/junit-xml-report.xml", "w") as test_summary:
-        test_summary.write('<?xml version="1.0" encoding="utf-8"?>')
+        test_summary.write('<?xml version="1.0" encoding="utf-8"?>\n')
         test_summary.write(
-            f'<testsuite errors="0" name="cc-link-checker" skipped="0" tests="1" time="{time.time()-START_TIME}">'
+            f'<testsuite errors="0" name="cc-link-checker" skipped="0" tests="1" time="{time.time()-START_TIME}">\n'
         )
         test_summary.write(
-            '<testcase classname="test_broken_links" name="check broken links" file="link_checker.py">'
+            '<testcase classname="test_broken_links" name="check broken links" file="link_checker.py">\n'
         )
         if errors_total != 0:
             test_summary.write(
-                f'<failure message="{errors_total} broken links found">Number of error links: {errors_total}\nNumber of unique broken links: {len(MAP_BROKEN_LINKS.keys())}</failure>'
+                f'<failure message="{errors_total} broken links found">Number of error links: {errors_total}\nNumber of unique broken links: {len(MAP_BROKEN_LINKS.keys())}</failure>\n'
             )
         test_summary.write("</testcase></testsuite>")
 

--- a/link_checker.py
+++ b/link_checker.py
@@ -65,7 +65,7 @@ def parse_argument(args):
     )
     parser.add_argument(
         "--output-error",
-        help="Outputs all link errors to file (default: errorlog.txt)",
+        help="Outputs all link errors to file (default: errorlog.txt) and creates junit-xml type script run summary(test-summary/junit-xml-report.xml) for CI",
         metavar="output_file",
         const="errorlog.txt",
         nargs="?",

--- a/link_checker.py
+++ b/link_checker.py
@@ -460,6 +460,29 @@ def output_summary(all_links, num_errors):
             output_write(url)
 
 
+def output_test_summary(errors_total):
+    """Prints summary of script output in form of junit-xml
+
+    Args:
+        errors_total (int): Total number of broken links
+    """
+    if not os.path.isdir("test-summary"):
+        os.mkdir("test-summary")
+    with open("test-summary/junit-xml-report.xml", "w") as test_summary:
+        test_summary.write('<?xml version="1.0" encoding="utf-8"?>')
+        test_summary.write(
+            f'<testsuite errors="0" name="cc-link-checker" skipped="0" tests="1" time="{time.time()-START_TIME}">'
+        )
+        test_summary.write(
+            '<testcase classname="test_broken_links" name="check broken links" file="link_checker.py">'
+        )
+        if errors_total != 0:
+            test_summary.write(
+                f'<failure message="{errors_total} broken links found">Number of error links: {errors_total}\nNumber of unique broken links: {len(MAP_BROKEN_LINKS.keys())}</failure>'
+            )
+        test_summary.write("</testcase></testsuite>")
+
+
 def main():
     parse_argument(sys.argv[1:])
 
@@ -548,6 +571,8 @@ def main():
     if OUTPUT_ERR:
         output_summary(all_links, errors_total)
         print("\nError file present at: ", OUTPUT.name)
+        output_test_summary(errors_total)
+
     sys.exit(ERR_CODE)
 
 

--- a/test_link_checker.py
+++ b/test_link_checker.py
@@ -329,3 +329,33 @@ def test_request_local_text():
     # Change local path to current directory
     link_checker.LICENSE_LOCAL_PATH = "./"
     assert link_checker.request_local_text("test_file.txt") == random_string
+
+
+@pytest.mark.parametrize(
+    "errors_total, map_links",
+    [(3, {"link1": ["file1", "file3"], "link2": ["file1"]}), (0, {})],
+)
+def test_output_test_summary(errors_total, map_links):
+    link_checker.OUTPUT_ERR = True
+    link_checker.MAP_BROKEN_LINKS = map_links
+    link_checker.output_test_summary(errors_total)
+    with open("test-summary/junit-xml-report.xml", "r") as test_summary:
+        assert (
+            test_summary.readline()
+            == '<?xml version="1.0" encoding="utf-8"?>\n'
+        )
+        test_summary.readline()
+        assert (
+            test_summary.readline()
+            == '<testcase classname="test_broken_links" name="check broken links" file="link_checker.py">\n'
+        )
+        if errors_total != 0:
+            assert (
+                test_summary.readline()
+                == '<failure message="3 broken links found">Number of error links: 3\n'
+            )
+            assert (
+                test_summary.readline()
+                == "Number of unique broken links: 2</failure>\n"
+            )
+        assert test_summary.readline() == "</testcase></testsuite>"

--- a/test_link_checker.py
+++ b/test_link_checker.py
@@ -340,22 +340,16 @@ def test_output_test_summary(errors_total, map_links):
     link_checker.MAP_BROKEN_LINKS = map_links
     link_checker.output_test_summary(errors_total)
     with open("test-summary/junit-xml-report.xml", "r") as test_summary:
-        assert (
-            test_summary.readline()
-            == '<?xml version="1.0" encoding="utf-8"?>\n'
-        )
-        test_summary.readline()
-        assert (
-            test_summary.readline()
-            == '<testcase classname="test_broken_links" name="check broken links" file="link_checker.py">\n'
-        )
         if errors_total != 0:
+            test_summary.readline()
+            test_summary.readline()
+            test_summary.readline()
+            test_summary.readline()
             assert (
                 test_summary.readline()
-                == '<failure message="3 broken links found">Number of error links: 3\n'
+                == '\t\t\t<failure message="3 broken links found" type="failure">Number of error links: 3\n'
             )
             assert (
                 test_summary.readline()
                 == "Number of unique broken links: 2</failure>\n"
             )
-        assert test_summary.readline() == "</testcase></testsuite>"


### PR DESCRIPTION
<!-- Please replace #XX below with an existing issue number. Remove the line entirely if none exist. -->
Fixes #21 

**Description**
When user uses `--output-error` along with the script results, a `test-summary/junit-xml-report.xml` inside working directory of the script. The test-summary contains number of broken links found and number of unique broken links.

**Checklist:**
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
