### PR TITLE
only display Warning: message if there are warnings

### DIFF
--- a/link_checker.py
+++ b/link_checker.py
@@ -421,8 +421,7 @@ def write_response(all_links, response, base_url, license_name, valid_anchors):
             map_links_file(all_links[idx], base_url)
             caught_errors += 1
             if caught_errors == 1:
-                if not VERBOSE:
-                    print("Errors:")
+                print("Errors:")
                 output_write("\n{}\nURL: {}".format(license_name, base_url))
             result = "  {:<24}{}".format(str(status), valid_anchors[idx])
             print(result)

--- a/link_checker.py
+++ b/link_checker.py
@@ -258,6 +258,7 @@ def get_scrapable_links(base_url, links_in_license):
     """
     valid_links = []
     valid_anchors = []
+    warnings = []
     for link in links_in_license:
         try:
             href = link["href"]
@@ -267,21 +268,23 @@ def get_scrapable_links(base_url, links_in_license):
             except KeyError:
                 try:
                     assert link["name"]
-                    verbose_print(
+                    warnings.append(
                         "  {:<24}{}".format("Anchor uses name", link)
                     )
                 except:
-                    verbose_print(
+                    warnings.append(
                         "  {:<24}{}".format("Anchor w/o href or id", link)
                     )
             continue
         if href[0] == "#":
+            # anchor links are valid, but out of scope
             # No need to report non-issue (not actionable)
             # verbose_print(
             #     "  {:<24}{}".format("Skipping internal link ", link)
             # )
             continue
         if href.startswith("mailto:"):
+            # mailto links are valid, but out of scope
             # No need to report non-issue (not actionable)
             # verbose_print(
             #     "  {:<24}{}".format("Skipping mailto link ", link)
@@ -290,6 +293,9 @@ def get_scrapable_links(base_url, links_in_license):
         analyze = urlsplit(href)
         valid_links.append(create_absolute_link(base_url, analyze))
         valid_anchors.append(link)
+    if warnings:
+        verbose_print("Warnings:")
+        print("\n".join(warnings))
     return (valid_anchors, valid_links)
 
 
@@ -523,7 +529,6 @@ def main():
         license_soup = BeautifulSoup(source_html, "lxml")
         links_in_license = license_soup.find_all("a")
         verbose_print("Number of links found:", len(links_in_license))
-        verbose_print("Errors and Warnings:")
         valid_anchors, valid_links = get_scrapable_links(
             base_url, links_in_license
         )


### PR DESCRIPTION
## Description
only display "Warning:" message if there are warnings

prior behavior was to output "Errors and Warnings:" for every single file (regardless of whether there were warnings or not. I removed "Errors" since the messages are only displayed with `-v` verbose option (which matches warning behavior).

given above behavior change, always display "Errors:" when there are errors.

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
