### PR TITLE
Improve license names handling

### DIFF
--- a/link_checker.py
+++ b/link_checker.py
@@ -108,6 +108,8 @@ def get_local_licenses():
     # Catching permission denied(OS ERROR) or other errors
     except:
         raise
+    # Although license_names_unordered is sorted below, is not ordered
+    # according to TEST_ORDER.
     license_names_unordered.sort()
     license_names = []
     # Test newer licenses first (they are the most volatile) and exclude
@@ -139,6 +141,8 @@ def get_github_licenses():
     license_names_unordered = []
     for link in soup.table.tbody.find_all("a", class_="js-navigation-open"):
         license_names_unordered.append(link.string)
+    # Although license_names_unordered is sorted below, is not ordered
+    # according to TEST_ORDER.
     license_names_unordered.sort()
     license_names = []
     # Test newer licenses first (they are the most volatile) and exclude

--- a/link_checker.py
+++ b/link_checker.py
@@ -93,7 +93,7 @@ def parse_argument(args):
         LOCAL = True
 
 
-def get_local_license():
+def get_local_licenses():
     """This function get all the licenses stored locally
 
     Returns:
@@ -108,6 +108,7 @@ def get_local_license():
     # Catching permission denied(OS ERROR) or other errors
     except:
         raise
+    links.sort()
     links_ordered = list()
     # Test newer licenses first (they are the most volatile) and exclude
     # non-.html files
@@ -123,7 +124,7 @@ def get_local_license():
     return links
 
 
-def get_global_license():
+def get_github_licenses():
     """This function scrapes all the license file in the repo:
     https://github.com/creativecommons/creativecommons.org/tree/master/docroot/legalcode
 
@@ -136,7 +137,10 @@ def get_global_license():
     )
     page_text = request_text(URL)
     soup = BeautifulSoup(page_text, "lxml")
-    links = soup.table.tbody.find_all("a", class_="js-navigation-open")
+    links = []
+    for link in soup.table.tbody.find_all("a", class_="js-navigation-open"):
+        links.append(link.string)
+    links.sort()
     links_ordered = list()
     # Test newer licenses first (they are the most volatile) and exclude
     # non-.html files
@@ -499,20 +503,15 @@ def main():
     parse_argument(sys.argv[1:])
 
     if LOCAL:
-        all_links = get_local_license()
+        all_links = get_local_licenses()
     else:
-        all_links = get_global_license()
+        all_links = get_github_licenses()
 
     errors_total = 0
     exit_status = 0
-    for license in all_links:
-        try:
-            license_name = license.string
-        except AttributeError:
-            license_name = license
+    for license_name in all_links:
         caught_errors = 0
-        print("\n")
-        print("Checking:", license_name)
+        print("\n\nChecking:", license_name)
         # Refer to issue for more info on samplingplus_1.0.br.htm:
         #   https://github.com/creativecommons/cc-link-checker/issues/9
         if license_name == "samplingplus_1.0.br.html":

--- a/test_link_checker.py
+++ b/test_link_checker.py
@@ -31,8 +31,8 @@ def test_parse_argument(reset_global):
     assert link_checker.LOCAL is True
 
 
-def test_get_global_license():
-    all_links = link_checker.get_global_license()
+def test_get_github_licenses():
+    all_links = link_checker.get_github_licenses()
     assert len(all_links) > 0
 
 


### PR DESCRIPTION
## Description
sort license names and improve clarity and consistency of function and variable names

sorted license file names results in more deterministic output which allows for easier and more accurate comparisons of the output

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
