### PR TITLE
Reduce globals and use tempdir for tests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ link_checker = "python ./link_checker.py"
 
 [dev-packages]
 # See https://github.com/pypa/pipenv/issues/1760
-black = {ref = "19.3b0",git = "https://github.com/python/black.git"}
+black = {ref = "19.10b0",git = "https://github.com/python/black.git"}
 flake8 = "*"
 pytest = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "aeaeb66a17073203586e38c5cf98ea3e12066c86f8e6346833208bd375aea2ff"
+            "sha256": "c8d45f402f11f28b5e085440018954183ba595f27f4b4bb53fca5a88d3e2881b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,19 +18,19 @@
     "default": {
         "beautifulsoup4": {
             "hashes": [
-                "sha256:5279c36b4b2ec2cb4298d723791467e3000e5384a43ea0cdf5d45207c7e97169",
-                "sha256:6135db2ba678168c07950f9a16c4031822c6f4aec75a65e0a97bc5ca09789931",
-                "sha256:dcdef580e18a76d54002088602eba453eec38ebbcafafeaabd8cab12b6155d57"
+                "sha256:05fd825eb01c290877657a56df4c6e4c311b3965bda790c613a3d6fb01a5462a",
+                "sha256:9fbb4d6e48ecd30bcacc5b63b94088192dcda178513b2ae3c394229f8911b887",
+                "sha256:e1505eeed31b0f4ce2dbb3bc8eb256c04cc2b3b72af7d551a4ab6efd5cbe5dae"
             ],
             "index": "pypi",
-            "version": "==4.8.1"
+            "version": "==4.8.2"
         },
         "certifi": {
             "hashes": [
-                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
-                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
+                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
+                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
             ],
-            "version": "==2019.9.11"
+            "version": "==2019.11.28"
         },
         "chardet": {
             "hashes": [
@@ -116,35 +116,35 @@
         },
         "lxml": {
             "hashes": [
-                "sha256:02ca7bf899da57084041bb0f6095333e4d239948ad3169443f454add9f4e9cb4",
-                "sha256:096b82c5e0ea27ce9138bcbb205313343ee66a6e132f25c5ed67e2c8d960a1bc",
-                "sha256:0a920ff98cf1aac310470c644bc23b326402d3ef667ddafecb024e1713d485f1",
-                "sha256:1409b14bf83a7d729f92e2a7fbfe7ec929d4883ca071b06e95c539ceedb6497c",
-                "sha256:17cae1730a782858a6e2758fd20dd0ef7567916c47757b694a06ffafdec20046",
-                "sha256:17e3950add54c882e032527795c625929613adbd2ce5162b94667334458b5a36",
-                "sha256:1f4f214337f6ee5825bf90a65d04d70aab05526c08191ab888cb5149501923c5",
-                "sha256:2e8f77db25b0a96af679e64ff9bf9dddb27d379c9900c3272f3041c4d1327c9d",
-                "sha256:4dffd405390a45ecb95ab5ab1c1b847553c18b0ef8ed01e10c1c8b1a76452916",
-                "sha256:6b899931a5648862c7b88c795eddff7588fb585e81cecce20f8d9da16eff96e0",
-                "sha256:726c17f3e0d7a7200718c9a890ccfeab391c9133e363a577a44717c85c71db27",
-                "sha256:760c12276fee05c36f95f8040180abc7fbebb9e5011447a97cdc289b5d6ab6fc",
-                "sha256:796685d3969815a633827c818863ee199440696b0961e200b011d79b9394bbe7",
-                "sha256:891fe897b49abb7db470c55664b198b1095e4943b9f82b7dcab317a19116cd38",
-                "sha256:9277562f175d2334744ad297568677056861070399cec56ff06abbe2564d1232",
-                "sha256:a471628e20f03dcdfde00770eeaf9c77811f0c331c8805219ca7b87ac17576c5",
-                "sha256:a63b4fd3e2cabdcc9d918ed280bdde3e8e9641e04f3c59a2a3109644a07b9832",
-                "sha256:ae88588d687bd476be588010cbbe551e9c2872b816f2da8f01f6f1fda74e1ef0",
-                "sha256:b0b84408d4eabc6de9dd1e1e0bc63e7731e890c0b378a62443e5741cfd0ae90a",
-                "sha256:be78485e5d5f3684e875dab60f40cddace2f5b2a8f7fede412358ab3214c3a6f",
-                "sha256:c27eaed872185f047bb7f7da2d21a7d8913457678c9a100a50db6da890bc28b9",
-                "sha256:c7fccd08b14aa437fe096c71c645c0f9be0655a9b1a4b7cffc77bcb23b3d61d2",
-                "sha256:c81cb40bff373ab7a7446d6bbca0190bccc5be3448b47b51d729e37799bb5692",
-                "sha256:d11874b3c33ee441059464711cd365b89fa1a9cf19ae75b0c189b01fbf735b84",
-                "sha256:e9c028b5897901361d81a4718d1db217b716424a0283afe9d6735fe0caf70f79",
-                "sha256:fe489d486cd00b739be826e8c1be188ddb74c7a1ca784d93d06fda882a6a1681"
+                "sha256:00ac0d64949fef6b3693813fe636a2d56d97a5a49b5bbb86e4cc4cc50ebc9ea2",
+                "sha256:0571e607558665ed42e450d7bf0e2941d542c18e117b1ebbf0ba72f287ad841c",
+                "sha256:0e3f04a7615fdac0be5e18b2406529521d6dbdb0167d2a690ee328bef7807487",
+                "sha256:13cf89be53348d1c17b453867da68704802966c433b2bb4fa1f970daadd2ef70",
+                "sha256:217262fcf6a4c2e1c7cb1efa08bd9ebc432502abc6c255c4abab611e8be0d14d",
+                "sha256:223e544828f1955daaf4cefbb4853bc416b2ec3fd56d4f4204a8b17007c21250",
+                "sha256:277cb61fede2f95b9c61912fefb3d43fbd5f18bf18a14fae4911b67984486f5d",
+                "sha256:3213f753e8ae86c396e0e066866e64c6b04618e85c723b32ecb0909885211f74",
+                "sha256:4690984a4dee1033da0af6df0b7a6bde83f74e1c0c870623797cec77964de34d",
+                "sha256:4fcc472ef87f45c429d3b923b925704aa581f875d65bac80f8ab0c3296a63f78",
+                "sha256:61409bd745a265a742f2693e4600e4dbd45cc1daebe1d5fad6fcb22912d44145",
+                "sha256:678f1963f755c5d9f5f6968dded7b245dd1ece8cf53c1aa9d80e6734a8c7f41d",
+                "sha256:6c6d03549d4e2734133badb9ab1c05d9f0ef4bcd31d83e5d2b4747c85cfa21da",
+                "sha256:6e74d5f4d6ecd6942375c52ffcd35f4318a61a02328f6f1bd79fcb4ffedf969e",
+                "sha256:7b4fc7b1ecc987ca7aaf3f4f0e71bbfbd81aaabf87002558f5bc95da3a865bcd",
+                "sha256:7ed386a40e172ddf44c061ad74881d8622f791d9af0b6f5be20023029129bc85",
+                "sha256:8f54f0924d12c47a382c600c880770b5ebfc96c9fd94cf6f6bdc21caf6163ea7",
+                "sha256:ad9b81351fdc236bda538efa6879315448411a81186c836d4b80d6ca8217cdb9",
+                "sha256:bbd00e21ea17f7bcc58dccd13869d68441b32899e89cf6cfa90d624a9198ce85",
+                "sha256:c3c289762cc09735e2a8f8a49571d0e8b4f57ea831ea11558247b5bdea0ac4db",
+                "sha256:cf4650942de5e5685ad308e22bcafbccfe37c54aa7c0e30cd620c2ee5c93d336",
+                "sha256:cfcbc33c9c59c93776aa41ab02e55c288a042211708b72fdb518221cc803abc8",
+                "sha256:e301055deadfedbd80cf94f2f65ff23126b232b0d1fea28f332ce58137bcdb18",
+                "sha256:ebbfe24df7f7b5c6c7620702496b6419f6a9aa2fd7f005eb731cc80d7b4692b9",
+                "sha256:eff69ddbf3ad86375c344339371168640951c302450c5d3e9936e98d6459db06",
+                "sha256:f6ed60a62c5f1c44e789d2cf14009423cb1646b44a43e40a9cf6a21f077678a1"
             ],
             "index": "pypi",
-            "version": "==4.4.1"
+            "version": "==4.4.2"
         },
         "requests": {
             "hashes": [
@@ -156,10 +156,10 @@
         },
         "six": {
             "hashes": [
-                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
-                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
             ],
-            "version": "==1.13.0"
+            "version": "==1.14.0"
         },
         "soupsieve": {
             "hashes": [
@@ -186,7 +186,7 @@
         },
         "black": {
             "git": "https://github.com/python/black.git",
-            "ref": "026c81b83454f176a9f9253cbfb70be2c159d822"
+            "ref": "6bedb5c58a7d8c25aa9509f8217bc24e9797e90d"
         },
         "entrypoints": {
             "hashes": [
@@ -205,11 +205,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26",
-                "sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"
+                "sha256:bdd9b7c397c273bcc9a11d6629a38487cd07154fa255a467bf704cd2c258e359",
+                "sha256:f17c015735e1a88296994c0697ecea7e11db24290941983b08c9feb30921e6d8"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==0.23"
+            "version": "==1.4.0"
         },
         "mccabe": {
             "hashes": [
@@ -220,17 +220,17 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
-                "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
+                "sha256:1a2a32c72400d365000412fe08eb4a24ebee89997c18d3d147544f70f5403b39",
+                "sha256:c468adec578380b6281a114cb8a5db34eb1116277da92d7c46f904f0b52d3288"
             ],
-            "version": "==7.2.0"
+            "version": "==8.1.0"
         },
         "packaging": {
             "hashes": [
-                "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
-                "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"
+                "sha256:aec3fdbb8bc9e4bb65f0634b9f551ced63983a529d6a8931817d52fdd0816ddb",
+                "sha256:fe1d8331dfa7cc0a883b49d75fc76380b2ab2734b220fbb87d774e4fd4b851f8"
             ],
-            "version": "==19.2"
+            "version": "==20.0"
         },
         "pluggy": {
             "hashes": [
@@ -241,10 +241,10 @@
         },
         "py": {
             "hashes": [
-                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
-                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
+                "sha256:5e27081401262157467ad6e7f851b7aa402c5852dbcb3dae06768434de5752aa",
+                "sha256:c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"
             ],
-            "version": "==1.8.0"
+            "version": "==1.8.1"
         },
         "pycodestyle": {
             "hashes": [
@@ -262,39 +262,39 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f",
-                "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"
+                "sha256:4c830582a84fb022400b85429791bc551f1f4871c33f23e44f353119e92f969f",
+                "sha256:c342dccb5250c08d45fd6f8b4a559613ca603b57498511740e65cd11a2e7dcec"
             ],
-            "version": "==2.4.5"
+            "version": "==2.4.6"
         },
         "pytest": {
             "hashes": [
-                "sha256:63344a2e3bce2e4d522fd62b4fdebb647c019f1f9e4ca075debbd13219db4418",
-                "sha256:f67403f33b2b1d25a6756184077394167fe5e2f9d8bdaab30707d19ccec35427"
+                "sha256:6b571215b5a790f9b41f19f3531c53a45cf6bb8ef2988bc1ff9afb38270b25fa",
+                "sha256:e41d489ff43948babd0fad7ad5e49b8735d5d55e26628a58673c39ff61d95de4"
             ],
             "index": "pypi",
-            "version": "==5.3.1"
+            "version": "==5.3.2"
         },
         "six": {
             "hashes": [
-                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
-                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
             ],
-            "version": "==1.13.0"
+            "version": "==1.14.0"
         },
         "wcwidth": {
             "hashes": [
-                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
-                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+                "sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603",
+                "sha256:f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8"
             ],
-            "version": "==0.1.7"
+            "version": "==0.1.8"
         },
         "zipp": {
             "hashes": [
-                "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e",
-                "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"
+                "sha256:8dda78f06bd1674bd8720df8a50bb47b6e1233c503a4eed8e7810686bde37656",
+                "sha256:d38fbe01bbf7a3593a32bc35a9c4453c32bc42b98c377f9bff7e9f8da157786c"
             ],
-            "version": "==0.6.0"
+            "version": "==1.0.0"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <a href="https://circleci.com/gh/creativecommons/cc-link-checker"><img alt="CircleCI" src="https://img.shields.io/circleci/build/github/creativecommons/cc-link-checker.svg"></a> <a href="./LICENSE"><img alt="Licence: MIT" src="https://img.shields.io/github/license/creativecommons/cc-link-checker.svg"></a> <a href="https://github.com/python/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a> <a href="https://opensource.creativecommons.org/community/#slack"><img alt="chat: on Slack" src="https://img.shields.io/badge/chat-on%20Slack-blue"></a>
 </p>
 
+
 ## Table of Contents
 
 -   [Pre-requisite](#Pre-requisite)
@@ -14,6 +15,7 @@
 -   [Usage](#Usage)
     -   [`-h` or `--help`](#-h-or---help)
     -   [Default mode](#default-mode)
+    -   [`-q` or `--quiet`](#-q-or---quiet)
     -   [`-v` or `--verbose`](#-v-or---verbose)
     -   [`--output-error`](#--output-error)
     -   [`--local`](#--local)
@@ -24,10 +26,12 @@
 -   [Contributing](#Contributing)
 -   [License](#License)
 
+
 ## Pre-requisite
 
 -   Python3
 -   UTF-8 supported console
+
 
 ## Installation
 
@@ -35,15 +39,17 @@ There are two suggested ways of installation. Use [User](#User), if you are
 interested in just running the script. Use [Development](#Development), if you
 are interested in developing the script
 
+
 ### User
 
 1. Clone the repo
     ```shell
     git clone https://github.com/creativecommons/cc-link-checker.git
     ```
-2. Install dependencies  
-   Using **requirements.txt**: `pip install -r requirements.txt`  
+2. Install dependencies
+   Using **requirements.txt**: `pip install -r requirements.txt`
    Using **Pipfile** (requires [pipenv](https://github.com/pypa/pipenv)): `pipenv install`
+
 
 ### Development
 
@@ -72,50 +78,64 @@ We recommend using [pipenv](https://github.com/pypa/pipenv) to create a virtual 
         pipenv run link_checker.py
         ```
 
+
 ## Usage
+
 
 ### `-h` or `--help`
 
 It provides the help text related to the script
 
+```shell
+pipenv run link_checker.py -h
 ```
-$ python link_checker.py -h
-Script to check broken links in CC licenses
+```
+usage: link_checker.py [-h] [--local] [--output-errors [output_file]] [-q]
+                       [--root-url ROOT_URL] [-v]
+
+Check for broken links in Creative Commons licenses
 
 optional arguments:
   -h, --help            show this help message and exit
-  -v, --verbose         Increase verbosity of output
-  --output-error [output_file]
-                        Outputs all link errors to file (default:
-                        errorlog.txt) and creates junit-xml type summary(test-
-                        summary/junit-xml-report.xml)
   --local               Scrapes license files from local file system
+  --output-errors [output_file]
+                        Outputs all link errors to file (default: errorlog.txt)
+                        and creates junit-xml type summary(test-summary/junit-xml-
+                        report.xml)
+  -q, --quiet           Decrease verbosity. Can be specified multiple times.
+  --root-url ROOT_URL   Set root URL (default: https://creativecommons.org)
+  -v, --verbose         Increase verbosity. Can be specified multiple times.
 ```
 
 ### Default mode
 
-This mode shows which file is currently being checked along with errors
-encountered in the links
+This mode shows which file is currently being checked along with warnings and
+errors encountered in the links
 
 ```shell
 pipenv run link_checker.py
 ```
 
+
+### `-q` or `--quiet`
+
+This flag decreases the verbosity of the output. This mode is useful for
+reducing the noise. By default, WARNING and higher output is displayed.
+
+```shell
+pipenv run link_checker.py -q
+```
+
+
 ### `-v` or `--verbose`
 
 This flag increases the verbosity of the output. This mode is useful for
-in-depth debugging
+in-depth debugging. By default, WARNING and higher output is displayed.
 
 ```shell
 pipenv run link_checker.py -v
 ```
 
-The output contains:
-
--   File currently being checked
--   Errors in the links
--   Warnings in the link
--   Skipped files and links
 
 ### `--output-error`
 
@@ -135,6 +155,7 @@ pipenv run link_checker.py --output-error output\results.txt
 This flag also creates a `junit-xml` format summary of script run containing number of error links and number of unique error links.
 
 The location of this file will be `test-summary/junit-xml-report.xml`. This xml file can be passed to CI to show failure result.
+
 
 ### `--local`
 
@@ -164,6 +185,7 @@ This mode can be helpful for using script as a CI.
 
 **Note:** You can manually change the relative local path by changing `LICENSE_LOCAL_PATH` global variable in the script.
 
+
 ## Integrating with CI
 
 Due to the script capability to scrape licenses from local storage, it can be used as CI in 2 easy steps:-
@@ -181,6 +203,7 @@ Due to the script capability to scrape licenses from local storage, it can be us
 
 The example configuration for **CircleCI** is present [here](examples/CircleCI/config.yml).
 
+
 ## Unit Testing
 
 Unit tests have been written using [pytest](https://docs.pytest.org/en/latest/)
@@ -195,16 +218,24 @@ framework. The tests can be run using:
     pipenv run pytest -v
     ```
 
+
 ## Troubleshooting
 
--   `UnicodeEncodeError`  
+-   `UnicodeEncodeError`
     This error is thrown when the console is not UTF-8 supported.
 
--   Failing **Lint** build  
+-   Failing **Lint** build
     Currently we follow customised [black](https://github.com/python/black) code
     style alongwith [flake8](https://gitlab.com/pycqa/flake8). The [black
     configuration](pyproject.toml) and [flake8 configuration](.flake8) are
-    present in the repo. Do follow them to pass the CI build
+    present in the repo. Do follow them to pass the CI build:
+    ```shell
+    black ./
+    ```
+    ```
+    flake8 ./
+    ```
+
 
 ## Code of Conduct
 
@@ -219,10 +250,12 @@ framework. The tests can be run using:
 [code_of_conduct]: https://creativecommons.github.io/community/code-of-conduct/
 [reporting_guide]: https://creativecommons.github.io/community/code-of-conduct/enforcement/
 
+
 ## Contributing
 
 We welcome contributions for bug fixes, enhancement and documentation. Please
 follow [`CONTRIBUTING.md`](CONTRIBUTING.md) while contributing.
+
 
 ## License
 

--- a/link_checker.py
+++ b/link_checker.py
@@ -104,7 +104,7 @@ def parse_argument(arguments):
             args.log_level += v
         if args.log_level < DEBUG:
             args.log_level = DEBUG
-        if args.log_level > CRITICAL:
+        elif args.log_level > CRITICAL:
             args.log_level = CRITICAL
     if not args.output_errors:
         args.output_errors = None

--- a/test_link_checker.py
+++ b/test_link_checker.py
@@ -7,28 +7,27 @@ import grequests
 
 @pytest.fixture
 def reset_global():
-    link_checker.VERBOSE = False
-    link_checker.OUTPUT_ERR = False
     link_checker.MEMOIZED_LINKS = {}
     link_checker.MAP_BROKEN_LINKS = {}
-    link_checker.LOCAL = False
     return
 
 
-def test_parse_argument(reset_global):
-    link_checker.parse_argument(["-v", "--output-error"])
-    assert link_checker.VERBOSE is True
-    assert link_checker.OUTPUT_ERR is True
-    assert link_checker.OUTPUT.name == "errorlog.txt"
-    link_checker.VERBOSE = False
-    link_checker.OUTPUT_ERR = False
-    link_checker.parse_argument(
-        ["--verbose", "--output-error", "err_file.txt", "--local"]
+def test_parse_argument(tmpdir):
+    args = link_checker.parse_argument([])
+    assert args.verbose is False
+    assert bool(args.output_errors) is False
+    args = link_checker.parse_argument(["-v", "--output-errors"])
+    assert args.verbose is True
+    assert bool(args.output_errors) is True
+    assert args.output_errors.name == "errorlog.txt"
+    output_file = tmpdir.join("errorlog.txt")
+    args = link_checker.parse_argument(
+        ["--verbose", "--output-errors", output_file.strpath, "--local"]
     )
-    assert link_checker.VERBOSE is True
-    assert link_checker.OUTPUT_ERR is True
-    assert link_checker.OUTPUT.name == "err_file.txt"
-    assert link_checker.LOCAL is True
+    assert args.verbose is True
+    assert bool(args.output_errors) is True
+    assert args.output_errors.name == output_file.strpath
+    assert args.local is True
 
 
 def test_get_github_licenses():
@@ -72,36 +71,39 @@ def test_get_github_licenses():
     ],
 )
 def test_create_base_link(filename, result):
-    baseURL = link_checker.create_base_link(filename)
+    args = link_checker.parse_argument([])
+    baseURL = link_checker.create_base_link(args, filename)
     assert baseURL == result
 
 
-def test_verbose_print(capsys, reset_global):
+def test_verbose_print(capsys):
     # verbose = False (default)
-    link_checker.verbose_print("Without verbose")
+    args = link_checker.parse_argument([])
+    link_checker.verbose_print(args, "Without verbose")
     # Set verbose True
-    link_checker.VERBOSE = True
-    link_checker.verbose_print("With verbose")
+    args = link_checker.parse_argument(["-v"])
+    link_checker.verbose_print(args, "With verbose")
     captured = capsys.readouterr()
     assert captured.out == "With verbose\n"
 
 
-def test_output_write(reset_global):
-    # OUTPUT_ERR = False (default)
-    link_checker.output_write("Output disabled")
-    # Set OUTPUT_ERR True
-    link_checker.OUTPUT_ERR = True
-    with open("errorlog.txt", "w+") as output_file:
-        link_checker.OUTPUT = output_file
-        link_checker.output_write("Output enabled")
-        # Seek to start of buffer
-        output_file.seek(0)
-        assert output_file.read() == "Output enabled\n"
+def test_output_write(tmpdir):
+    # output_errors is set and written to
+    output_file = tmpdir.join("errorlog.txt")
+    args = link_checker.parse_argument(
+        ["--output-errors", output_file.strpath]
+    )
+    link_checker.output_write(args, "Output enabled")
+    args.output_errors.flush()
+    assert output_file.read() == "Output enabled\n"
 
 
-def test_output_summary(reset_global):
-    # Set config
-    link_checker.OUTPUT_ERR = True
+def test_output_summary(reset_global, tmpdir):
+    # output_errors is set and written to
+    output_file = tmpdir.join("errorlog.txt")
+    args = link_checker.parse_argument(
+        ["--output-errors", output_file.strpath]
+    )
     link_checker.MAP_BROKEN_LINKS = {
         "https://link1.demo": [
             "https://file1.url/here",
@@ -109,46 +111,46 @@ def test_output_summary(reset_global):
         ],
         "https://link2.demo": ["https://file4.url/here"],
     }
-
-    # Open file for writing
-    with open("errorlog.txt", "w+") as output_file:
-        link_checker.OUTPUT = output_file
-        all_links = ["some link"] * 5
-        link_checker.output_summary(all_links, 3)
-        output_file.seek(0)
-        assert output_file.readline() == "\n"
-        assert output_file.readline() == "\n"
-        assert (
-            output_file.readline()
-            == "***************************************\n"
-        )
-        assert output_file.readline() == "                SUMMARY\n"
-        assert (
-            output_file.readline()
-            == "***************************************\n"
-        )
-        assert output_file.readline() == "\n"
-        assert str(output_file.readline()).startswith("Timestamp:")
-        assert output_file.readline() == "Total files checked: 5\n"
-        assert output_file.readline() == "Number of error links: 3\n"
-        assert output_file.readline() == "Number of unique broken links: 2\n"
-        assert output_file.readline() == "\n"
-        assert output_file.readline() == "\n"
-        assert (
-            output_file.readline()
-            == "Broken link - https://link1.demo found in:\n"
-        )
-        assert output_file.readline() == "https://file1.url/here\n"
-        assert output_file.readline() == "https://file2.url/goes/here\n"
-        assert output_file.readline() == "\n"
-        assert (
-            output_file.readline()
-            == "Broken link - https://link2.demo found in:\n"
-        )
-        assert output_file.readline() == "https://file4.url/here\n"
-
-    # Reset non global values
-    link_checker.all_links = []
+    all_links = ["some link"] * 5
+    link_checker.output_summary(args, all_links, 3)
+    args.output_errors.flush()
+    lines = output_file.readlines()
+    i = 0
+    assert lines[i] == "\n"
+    i += 1
+    assert lines[i] == "\n"
+    i += 1
+    assert lines[i] == "***************************************\n"
+    i += 1
+    assert lines[i] == "                SUMMARY\n"
+    i += 1
+    assert lines[i] == "***************************************\n"
+    i += 1
+    assert lines[i] == "\n"
+    i += 1
+    assert str(lines[i]).startswith("Timestamp:")
+    i += 1
+    assert lines[i] == "Total files checked: 5\n"
+    i += 1
+    assert lines[i] == "Number of error links: 3\n"
+    i += 1
+    assert lines[i] == "Number of unique broken links: 2\n"
+    i += 1
+    assert lines[i] == "\n"
+    i += 1
+    assert lines[i] == "\n"
+    i += 1
+    assert lines[i] == "Broken link - https://link1.demo found in:\n"
+    i += 1
+    assert lines[i] == "https://file1.url/here\n"
+    i += 1
+    assert lines[i] == "https://file2.url/goes/here\n"
+    i += 1
+    assert lines[i] == "\n"
+    i += 1
+    assert lines[i] == "Broken link - https://link2.demo found in:\n"
+    i += 1
+    assert lines[i] == "https://file4.url/here\n"
 
 
 @pytest.mark.parametrize(
@@ -172,6 +174,7 @@ def test_create_absolute_link(link, result):
 
 
 def test_get_scrapable_links():
+    args = link_checker.parse_argument([])
     test_file = (
         "<a name='hello'>without href</a>,"
         " <a href='#hello'>internal link</a>,"
@@ -183,7 +186,7 @@ def test_get_scrapable_links():
     test_case = soup.find_all("a")
     base_url = "https://www.demourl.com/dir1/dir2"
     valid_anchors, valid_links = link_checker.get_scrapable_links(
-        base_url, test_case
+        args, base_url, test_case
     )
     assert str(valid_anchors) == (
         '[<a href="https://creativecommons.ca">Absolute link</a>,'
@@ -217,9 +220,12 @@ def test_map_links_file(reset_global):
     }
 
 
-def test_write_response(reset_global):
+def test_write_response(tmpdir):
     # Set config
-    link_checker.OUTPUT_ERR = True
+    output_file = tmpdir.join("errorlog.txt")
+    args = link_checker.parse_argument(
+        ["--output-errors", output_file.strpath]
+    )
 
     # Text to extract valid_anchors
     text = (
@@ -244,27 +250,31 @@ def test_write_response(reset_global):
     license_name = "by-cc-nd_2.0"
 
     # Set output to external file
-    with open("errorlog.txt", "w+") as output_file:
-        link_checker.OUTPUT = output_file
-        caught_errors = link_checker.write_response(
-            all_links, response, base_url, license_name, valid_anchors
-        )
-        assert caught_errors == 2
-        output_file.seek(0)
-        assert output_file.readline() == "\n"
-        assert output_file.readline() == "by-cc-nd_2.0\n"
-        assert output_file.readline() == "URL: https://baseurl/goes/here\n"
-        assert output_file.readline() == (
-            "  Invalid Schema          "
-            '<a href="file://link3">Invalid Scheme</a>\n'
-        )
-        assert output_file.readline() == (
-            "  400                     "
-            '<a href="http://httpbin.org/status/400">Response 400</a>\n'
-        )
+    caught_errors = link_checker.write_response(
+        args, all_links, response, base_url, license_name, valid_anchors
+    )
+    assert caught_errors == 2
+    args.output_errors.flush()
+    lines = output_file.readlines()
+    i = 0
+    assert lines[i] == "\n"
+    i += 1
+    assert lines[i] == "by-cc-nd_2.0\n"
+    i += 1
+    assert lines[i] == "URL: https://baseurl/goes/here\n"
+    i += 1
+    assert lines[i] == (
+        "  Invalid Schema          "
+        '<a href="file://link3">Invalid Scheme</a>\n'
+    )
+    i += 1
+    assert lines[i] == (
+        "  400                     "
+        '<a href="http://httpbin.org/status/400">Response 400</a>\n'
+    )
 
 
-def test_get_memoized_result():
+def test_get_memoized_result(reset_global):
     text = (
         "<a href='link1'>Link 1</a>,"
         " <a href='link2'>Link 2</a>,"
@@ -356,8 +366,7 @@ def test_request_local_text():
     "errors_total, map_links",
     [(3, {"link1": ["file1", "file3"], "link2": ["file1"]}), (0, {})],
 )
-def test_output_test_summary(errors_total, map_links):
-    link_checker.OUTPUT_ERR = True
+def test_output_test_summary(errors_total, map_links, reset_global, tmpdir):
     link_checker.MAP_BROKEN_LINKS = map_links
     link_checker.output_test_summary(errors_total)
     with open("test-summary/junit-xml-report.xml", "r") as test_summary:


### PR DESCRIPTION
## Description

- Added --root-url (and moved local ROOT_URL to global  DEFAULT_ROOT_URL). This will allow comparison between production and staging.
- Updated to use args variable (passed between functions) to reduce global usage. This matches new --root-url behavior and will allow future updates to verbose behavior.
- update to use both -v/--verbose and -q/--quiet to allow either increasing or decreasing verbosity
- set default verbosity to WARNING
- Updated tests to use tmpdir to keep tests from overwriting errorlog.txt with worthless data
- sorted imports
- sorted arguments
- update version of black installed for dev (and CircleCI testing)

## Other information
<!-- Add any other information below or delete the "Other Information" line entirely. -->

## Checklist
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the `master` branch of the repository.
- [x] My commit messages follow [best practices][best_practices].
- [x] I added tests for the changes I made (if applicable).
- [x] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

<!-- Make sure you read and understand the following attestation. -->
## Developer Certificate of Origin
```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```
