### PR TITLE
refactored create_base_link() and added tested URL

### DIFF
--- a/test_link_checker.py
+++ b/test_link_checker.py
@@ -291,14 +291,14 @@ def test_write_response(tmpdir):
     i += 1
     assert lines[i] == "URL: https://baseurl/goes/here\n"
     i += 1
-    assert lines[i] == (
-        "  Invalid Schema          "
-        '<a href="file://link3">Invalid Scheme</a>\n'
-    )
+    assert lines[i] == f'  {"Invalid Schema":<24}file://link3\n'
+    i += 1
+    assert lines[i] == f'{"":<26}<a href="file://link3">Invalid Scheme</a>\n'
+    i += 1
+    assert lines[i] == f'  {"400":<24}http://httpbin.org/status/400\n'
     i += 1
     assert lines[i] == (
-        "  400                     "
-        '<a href="http://httpbin.org/status/400">Response 400</a>\n'
+        f'{"":<26}<a href="http://httpbin.org/status/400">Response 400</a>\n'
     )
 
 
@@ -403,11 +403,21 @@ def test_output_test_summary(errors_total, map_links, reset_global, tmpdir):
             test_summary.readline()
             test_summary.readline()
             test_summary.readline()
-            assert test_summary.readline() == (
-                "\t\t\t"
-                '<failure message="3 broken links found" type="failure">'
-                "Number of error links: 3\n"
-            )
+            try:
+                # type first, message second
+                assert test_summary.readline() == (
+                    '\t\t\t<failure type="failure"'
+                    ' message="3 broken links found">'
+                    "Number of error links: 3\n"
+                )
+            except AssertionError:
+                # message first, type second
+                assert test_summary.readline() == (
+                    '\t\t\t<failure message="3 broken links found"'
+                    ' type="failure">'
+                    "Number of error links: 3\n"
+                )
+
             assert (
                 test_summary.readline()
                 == "Number of unique broken links: 2</failure>\n"

--- a/test_link_checker.py
+++ b/test_link_checker.py
@@ -1,8 +1,13 @@
-import pytest
+# Standard library
 from urllib.parse import urlsplit
-import link_checker
+
+# Third-party
 from bs4 import BeautifulSoup
 import grequests
+import pytest
+
+# Local/library specific
+import link_checker
 
 
 @pytest.fixture
@@ -403,21 +408,11 @@ def test_output_test_summary(errors_total, map_links, reset_global, tmpdir):
             test_summary.readline()
             test_summary.readline()
             test_summary.readline()
-            try:
-                # type first, message second
-                assert test_summary.readline() == (
-                    '\t\t\t<failure type="failure"'
-                    ' message="3 broken links found">'
-                    "Number of error links: 3\n"
-                )
-            except AssertionError:
-                # message first, type second
-                assert test_summary.readline() == (
-                    '\t\t\t<failure message="3 broken links found"'
-                    ' type="failure">'
-                    "Number of error links: 3\n"
-                )
-
+            test_line = test_summary.readline()
+            assert test_line.startswith("\t\t\t<failure")
+            assert 'message="3 broken links found"' in test_line
+            assert 'type="failure"' in test_line
+            assert test_line.endswith(">Number of error links: 3\n")
             assert (
                 test_summary.readline()
                 == "Number of unique broken links: 2</failure>\n"

--- a/test_link_checker.py
+++ b/test_link_checker.py
@@ -408,11 +408,16 @@ def test_output_test_summary(errors_total, map_links, reset_global, tmpdir):
             test_summary.readline()
             test_summary.readline()
             test_summary.readline()
+
+            # The following is split up because sometimes message= is first and
+            # sometimes type= is first (ex. local macOS dev versus GitHub
+            # Actions Linux)
             test_line = test_summary.readline()
             assert test_line.startswith("\t\t\t<failure")
             assert 'message="3 broken links found"' in test_line
             assert 'type="failure"' in test_line
             assert test_line.endswith(">Number of error links: 3\n")
+
             assert (
                 test_summary.readline()
                 == "Number of unique broken links: 2</failure>\n"


### PR DESCRIPTION
## Description
- refactored `create_base_link()` to better represent pre-4.0 ported licenses
- added tested URL to error output for improved clarity

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [x] I added tests for the changes I made (if applicable).
- N/A I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
