### PR TITLE
[WIP] Adding support for plaintext legalcode check

### DIFF
--- a/link_checker/__main__.py
+++ b/link_checker/__main__.py
@@ -156,12 +156,6 @@ def parse_arguments(arguments):
             parser_shared_reporting,
         ],
     )
-    parser_legalcode.add_argument(
-        "--plaintext",
-        type=bool,
-        default=False,
-        help="Adding plaintext in check",
-    )
     parser_legalcode.set_defaults(func=check_legalcode)
 
     # RDF subcommand: link_checker rdf -h
@@ -345,7 +339,6 @@ def check_legalcode(args):
         )
         if ".txt" in license_name:
             plaintext_license = license_name.replace(".txt", "")
-            print(plaintext_license)
             licenses = plaintext_license.split("_")
             if len(licenses) == 2:
                 plaintext_url = "{}/licenses/{}/{}/legalcode.txt".format(

--- a/link_checker/__main__.py
+++ b/link_checker/__main__.py
@@ -156,6 +156,12 @@ def parse_arguments(arguments):
             parser_shared_reporting,
         ],
     )
+    parser_legalcode.add_argument(
+        "--plaintext",
+        type=bool,
+        default=False,
+        help="Adding plaintext in check",
+    )
     parser_legalcode.set_defaults(func=check_legalcode)
 
     # RDF subcommand: link_checker rdf -h
@@ -337,6 +343,16 @@ def check_legalcode(args):
         valid_anchors, valid_links, context_printed = get_scrapable_links(
             args, base_url, links_found, context, context_printed
         )
+        if ".txt" in license_name:
+            plaintext_license = license_name.replace(".txt", "")
+            print(plaintext_license)
+            licenses = plaintext_license.split("_")
+            if len(licenses) == 2:
+                plaintext_url = "{}/licenses/{}/{}/legalcode.txt".format(
+                    DEFAULT_ROOT_URL, licenses[0], licenses[1]
+                )
+                valid_links.append(plaintext_url)
+                valid_anchors.append("")
         if valid_links:
             memoized_results = get_memoized_result(valid_links, valid_anchors)
             stored_links = memoized_results[0]

--- a/link_checker/utils.py
+++ b/link_checker/utils.py
@@ -96,17 +96,17 @@ def get_legalcode(args):
     if args.local:
         if args.log_level == DEBUG:
             print("DEBUG: processing local legalcode files")
-        license_names = get_local_legalcode()
+        license_names = get_local_legalcode(args.plaintext)
     else:
         if args.log_level == DEBUG:
             print("DEBUG: processing GitHub legalcode files")
-        license_names = get_github_legalcode()
+        license_names = get_github_legalcode(args.plaintext)
     if args.limit and args.subcommand != "rdf":
         license_names = license_names[0 : args.limit]  # noqa: E203
     return license_names
 
 
-def get_github_legalcode():
+def get_github_legalcode(plaintext=False):
     """This function scrapes all the license file in the repo:
     https://github.com/creativecommons/creativecommons.org/tree/master/docroot/legalcode
 
@@ -130,15 +130,27 @@ def get_github_legalcode():
     # non-.html files
     for version in TEST_ORDER:
         for name in license_names_unordered:
-            if ".html" in name.string and version in name.string:
+            if (
+                ".html" in name.string
+                and version in name.string
+                or (
+                    plaintext
+                    and ".txt" in name.string
+                    and version in name.string
+                )
+            ):
                 license_names.append(name)
     for name in license_names_unordered:
-        if ".html" in name.string and name not in license_names:
+        if (
+            ".html" in name.string
+            and name not in license_names
+            or (plaintext and ".txt" in name.string and version in name.string)
+        ):
             license_names.append(name)
     return license_names
 
 
-def get_local_legalcode():
+def get_local_legalcode(plaintext=False):
     """This function get all the legalcode stored locally
 
     Returns:
@@ -161,10 +173,22 @@ def get_local_legalcode():
     # non-.html files
     for version in TEST_ORDER:
         for name in license_names_unordered:
-            if ".html" in name and version in name:
+            if (
+                ".html" in name
+                and version in name
+                or (
+                    plaintext
+                    and ".txt" in name.string
+                    and version in name.string
+                )
+            ):
                 license_names.append(name)
     for name in license_names_unordered:
-        if ".html" in name and name not in license_names:
+        if (
+            ".html" in name
+            and name not in license_names
+            or (plaintext and ".txt" in name.string and version in name.string)
+        ):
             license_names.append(name)
     return license_names
 

--- a/link_checker/utils.py
+++ b/link_checker/utils.py
@@ -96,17 +96,17 @@ def get_legalcode(args):
     if args.local:
         if args.log_level == DEBUG:
             print("DEBUG: processing local legalcode files")
-        license_names = get_local_legalcode(args.plaintext)
+        license_names = get_local_legalcode()
     else:
         if args.log_level == DEBUG:
             print("DEBUG: processing GitHub legalcode files")
-        license_names = get_github_legalcode(args.plaintext)
+        license_names = get_github_legalcode()
     if args.limit and args.subcommand != "rdf":
         license_names = license_names[0 : args.limit]  # noqa: E203
     return license_names
 
 
-def get_github_legalcode(plaintext=False):
+def get_github_legalcode():
     """This function scrapes all the license file in the repo:
     https://github.com/creativecommons/creativecommons.org/tree/master/docroot/legalcode
 
@@ -133,24 +133,20 @@ def get_github_legalcode(plaintext=False):
             if (
                 ".html" in name.string
                 and version in name.string
-                or (
-                    plaintext
-                    and ".txt" in name.string
-                    and version in name.string
-                )
+                or (".txt" in name.string and version in name.string)
             ):
                 license_names.append(name)
     for name in license_names_unordered:
         if (
             ".html" in name.string
             and name not in license_names
-            or (plaintext and ".txt" in name.string and version in name.string)
+            or (".txt" in name.string and version in name.string)
         ):
             license_names.append(name)
     return license_names
 
 
-def get_local_legalcode(plaintext=False):
+def get_local_legalcode():
     """This function get all the legalcode stored locally
 
     Returns:
@@ -176,18 +172,14 @@ def get_local_legalcode(plaintext=False):
             if (
                 ".html" in name
                 and version in name
-                or (
-                    plaintext
-                    and ".txt" in name.string
-                    and version in name.string
-                )
+                or (".txt" in name.string and version in name.string)
             ):
                 license_names.append(name)
     for name in license_names_unordered:
         if (
             ".html" in name
             and name not in license_names
-            or (plaintext and ".txt" in name.string and version in name.string)
+            or (".txt" in name.string and version in name.string)
         ):
             license_names.append(name)
     return license_names


### PR DESCRIPTION
## Fixes
<!-- If PR doesn't fully resolve the issue, replace 'Fixes' below with 'Related to'. -->
<!-- If there is no issue being resolved, open one before creating this pull request. -->
Fixes #68 by @TimidRobot. Please let me know if this is the right direction to take.

## Description
<!-- Concisely describe what the pull request does. -->
- Add support for plaintext by adding it as a argument for legalcode. If True, ".txt" will be included and check along with the ".html" files.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
- I follow what was suggested in #68 by adding plaintext as the argument for `get_legalcode`, `get_local_legalcode`, and `get_github_legalcode` functions and handle based on its boolean value.
- I was not sure if it was the right approach but I add plaintext as an argument for legalcode CLI. If true, it will include ".txt" when scraping for legal code.
- I try to make the minimal changes to `check_legalcode` function as I don't want to break anything so instead, if the current `license_name` includes ".txt", then append to `valid_links` and append `""` to `valid_anchors`. This way, `write_response` is not changed much. 

## Tests
<!-- Give steps for the reviewer to verify that this PR fixes the problem; or delete the section entirely. -->

## Screenshots
<!-- Add screenshots to show the problem and the solution; or delete the section entirely. -->

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
