### PR TITLE
fix get_local_index_rdf for 3.9 and improve variable names in get_links_from_rdf

### DIFF
--- a/link_checker/utils.py
+++ b/link_checker/utils.py
@@ -243,8 +243,8 @@ def get_local_index_rdf(local_path=""):
     """
     try:
         local_path = local_path or INDEX_RDF_LOCAL_PATH
-        index_rdf = open(local_path, "r")
-        rdf_text = index_rdf.read()
+        with open(local_path, "rb") as index_rdf:
+            rdf_text = index_rdf.read()
     except FileNotFoundError:
         raise CheckerError(
             f"Local index.rdf path({local_path}) does not exist"
@@ -266,15 +266,15 @@ def get_links_from_rdf(rdf_obj):
     """
     tags = rdf_obj.findChildren()
     links_found = []
-    for t in tags:
+    for tag in tags:
         # check link to deed and resources
-        el = {"tag": t, "href": ""}
-        if t.has_attr("rdf:resource"):
-            el["href"] = t["rdf:resource"]
-            links_found.append(el)
-        if t.has_attr("rdf:about"):
-            el["href"] = t["rdf:resource"]
-            links_found.append(el)
+        link = {"tag": tag, "href": ""}
+        if tag.has_attr("rdf:resource"):
+            link["href"] = tag["rdf:resource"]
+            links_found.append(link)
+        if tag.has_attr("rdf:about"):
+            link["href"] = tag["rdf:resource"]
+            links_found.append(link)
     return links_found
 
 


### PR DESCRIPTION
## Fixes
Fixes #121

## Description
- fix get_local_index_rdf for 3.9 and improve variable names in get_links_from_rdf
  - BeautifulSoup using lxml-xml works better with binary mode (works the same in 3.7, better in 3.9)

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. --> 
- [x] My pull request has a descriptive title (not a vague title like `Update
  index.md`).
- [x] My pull request targets the *default* branch of the repository (`main` or `master`).
- [x] My commit messages follow [best practices][best_practices].
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no
  visible errors.

[best_practices]:https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
